### PR TITLE
Create image for golang version 1.14

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -15,4 +15,3 @@ steps:
       from_secret: docker_password
   when:
     event: [tag, push]
-    branch: master

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ADD go
-FROM golang:1.15 as golang
+FROM golang:1.14 as golang
 
 FROM google/cloud-sdk:slim
 


### PR DESCRIPTION
As of 2020/12/24, 1.14 is required for GAE apps (1.15 is supported but is "in preview")