### PR TITLE
Update Go to 1.22, gcloud to 463

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM golang:1.21.0 as golang
+FROM golang:1.22.0 as golang
 
-FROM gcr.io/google.com/cloudsdktool/cloud-sdk:443.0.0-slim
+FROM gcr.io/google.com/cloudsdktool/cloud-sdk:463.0.0
 
 COPY --from=golang /usr/local/go/ /usr/local/go/
 
@@ -10,7 +10,10 @@ ENV PATH=$PATH:/usr/local/go/bin
 RUN go version
 
 # ADD make and java
-RUN apt-get install -y make default-jre
+RUN apt-get update && apt-get install -y make default-jre
 
-# ADD App Engine, Datastore emulator, and Firestore emulator
+# ADD App Engine, Datastore emulator, and Firestore emulator.
+# Leaving this here in case we figure out a way to install them in the :slim
+# version of the cloud-sdk docker image, but they're all included by default
+# in the full version of the image so this isn't technically necessary.
 RUN apt-get install -y google-cloud-cli-app-engine-go google-cloud-cli-datastore-emulator google-cloud-cli-firestore-emulator


### PR DESCRIPTION
463 is the latest at the time of writing 

https://console.cloud.google.com/gcr/images/google.com:cloudsdktool/GLOBAL/cloud-sdk
https://github.com/GoogleCloudPlatform/cloud-sdk-docker#components-installed-in-each-tag

also can't use `slim` because the `google-cloud-cli-app-engine-go` package can't be installed due to a python2.7 dependency

```
The following packages have unmet dependencies:
 google-cloud-cli-app-engine-python : Depends: python2.7 but it is not installable
```

