### PR TITLE
Update Go to 1.24 and gcloud sdk to 513.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM golang:1.23 as golang
+FROM golang:1.24 as golang
 
-FROM gcr.io/google.com/cloudsdktool/cloud-sdk:491.0.0
+FROM gcr.io/google.com/cloudsdktool/cloud-sdk:513.0.0
 
 COPY --from=golang /usr/local/go/ /usr/local/go/
 

--- a/README.md
+++ b/README.md
@@ -7,5 +7,18 @@ following `gcloud` components:
 - `app-engine-go`
 - `cloud-datastore-emulator`
 
+# Updating Instructions
+
+- Bump the major version of Go in `Dockerfile` to the latest Go version i.e.
+  `1.24`
+- Bump the version of `cloud-sdk` in `Dockerfile`
+  - Find the `latest` version [here][gcloud]
+- Open a Pull Request with those changes
+- Merge the Pull Request after review and tests pass
+- Tag a release using the Go version as the naming convention i.e. `1.24.0`
+- Verify the tag was pushed to [Docker Hub][dockerhub]
+
 [actions]: https://github.com/nytimes/golang-gcloud-sdk/actions
 [badge]: https://github.com/nytimes/golang-gcloud-sdk/actions/workflows/build.yml/badge.svg
+[gcloud]: https://gcr.io/google.com/cloudsdktool/cloud-sdk
+[dockerhub]: https://hub.docker.com/r/nytimes/golang-gcloud-sdk


### PR DESCRIPTION
gcloud sdk `513.0.0` is the latest at the time of sending this PR https://console.cloud.google.com/artifacts/docker/google.com:cloudsdktool/us/gcr.io/cloud-sdk?invt=AbrUWg&inv=1 

